### PR TITLE
Refactor widget module, improve logging, and update release workflow

### DIFF
--- a/scripts/build_appimage.py
+++ b/scripts/build_appimage.py
@@ -532,7 +532,10 @@ def download_appimagetool():
 
     if not appimagetool_path.exists():
         print("Downloading appimagetool...")
-        url = "https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage"
+        # AppImageKit is obsolete; the tool now lives in its own repo.
+        # See https://github.com/AppImage/AppImageKit/releases (deprecation
+        # notice) and https://github.com/AppImage/appimagetool/releases.
+        url = "https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage"
         run_command(["curl", "-L", "-o", str(appimagetool_path), url])
         os.chmod(appimagetool_path, 0o755)
 


### PR DESCRIPTION
This pull request updates the source URL for downloading `appimagetool` in the `download_appimagetool` function to reflect the tool's migration to its own repository, following the deprecation of `AppImageKit`.

Dependency update:

* Updated the download URL for `appimagetool` in `scripts/build_appimage.py` to use the new official repository, as `AppImageKit` is now obsolete.