### PR TITLE
Optimize AppImage by removing unused dependencies and modules

### DIFF
--- a/scripts/build_appimage.py
+++ b/scripts/build_appimage.py
@@ -81,7 +81,7 @@ print("Python path:", sys.path)
 print("LD_LIBRARY_PATH:", os.environ.get('LD_LIBRARY_PATH', ''))
 
 # Check for required commands
-for cmd in ['gsettings', 'xrandr', 'convert']:
+for cmd in ['gsettings', 'xrandr']:
     cmd_path = shutil.which(cmd)
     print(f"{cmd} found at: {cmd_path}")
 
@@ -490,7 +490,7 @@ def copy_system_commands(appdir):
     os.makedirs(target_lib, exist_ok=True)
 
     # List of commands to copy
-    commands = ["gsettings", "xrandr", "convert"]
+    commands = ["gsettings", "xrandr"]
 
     for cmd in commands:
         # Find the command path

--- a/scripts/build_appimage.py
+++ b/scripts/build_appimage.py
@@ -313,22 +313,10 @@ def install_dependencies(appdir):
         except Exception as e:
             print(f"Warning: Failed to copy {source}: {e}")
 
-    # Copy essential modules from system site-packages
-    print("Copying essential system modules...")
-    essential_modules = ["_distutils_hack", "pip", "setuptools", "pkg_resources"]
-    for module in essential_modules:
-        source = os.path.join(site_packages_path, module)
-        if os.path.exists(source):
-            target = os.path.join(target_site_packages, module)
-            try:
-                if os.path.isdir(source):
-                    shutil.copytree(source, target, symlinks=True, dirs_exist_ok=True)
-                else:
-                    shutil.copy2(source, target)
-            except Exception as e:
-                print(f"Warning: Failed to copy {source}: {e}")
-
-    # Copy our installed packages from the temporary venv
+    # Copy our installed packages from the temporary venv. pip,
+    # setuptools, pkg_resources and _distutils_hack are install-time
+    # tooling only and are never imported at runtime, so we skip them
+    # to keep the AppImage smaller.
     print("Copying installed packages...")
     for item in os.listdir(venv_site_packages):
         if item in ["__pycache__", "pip", "setuptools", "pkg_resources", "_distutils_hack"]:

--- a/scripts/build_appimage.py
+++ b/scripts/build_appimage.py
@@ -371,8 +371,225 @@ def install_dependencies(appdir):
     # Clean up the temporary venv
     shutil.rmtree(temp_venv)
 
+    # Trim unused PySide6/Qt6 modules before the ldd walk so we don't
+    # also chase host libs for code we just deleted.
+    trim_pyside6(target_site_packages)
+
     # Copy necessary system libraries for Qt
     copy_system_libraries(appdir)
+
+
+# PySide6/Qt6 modules that the runtime app does not import (it uses
+# QtCore + QtGui + QtWidgets only). Each prefix matches the shared lib
+# (libQt6<prefix>*.so*) and the PySide6 binding (Qt<prefix>.abi3.so /
+# .pyi). Kept conservative on edges (DBus, Network, OpenGL, Xcb,
+# Wayland) so file dialog portals and the X11/Wayland platform plugins
+# keep working.
+_PYSIDE6_MODULE_DENYLIST = (
+    "WebEngine",
+    "WebChannel",
+    "WebSockets",
+    "WebView",
+    "Pdf",
+    "Quick",
+    "Qml",
+    "3D",
+    "Charts",
+    "DataVisualization",
+    "Graphs",
+    "Multimedia",
+    "SpatialAudio",
+    "Bluetooth",
+    "Nfc",
+    "Positioning",
+    "Location",
+    "Sensors",
+    "SerialBus",
+    "SerialPort",
+    "Scxml",
+    "StateMachine",
+    "Test",
+    "Designer",
+    "Help",
+    "HttpServer",
+    "Sql",
+    "Svg",
+    "PrintSupport",
+    "UiTools",
+    "NetworkAuth",
+    "RemoteObjects",
+    "TextToSpeech",
+    "ShaderTools",
+    "Bodymovin",
+)
+
+# FFmpeg shared libs only ship for QtMultimedia, which we drop above.
+_FFMPEG_LIB_PREFIXES = ("libav", "libsw")
+
+# Top-level PySide6 entries that are devtools or build-time artifacts,
+# never needed by a packaged GUI app.
+_PYSIDE6_TOP_LEVEL_DROP = (
+    "qmlls",
+    "qmlformat",
+    "qmltestrunner",
+    "qmlimportscanner",
+    "qmlcachegen",
+    "qmllint",
+    "qmlplugindump",
+    "qmlpreview",
+    "qmlprofiler",
+    "qmlscene",
+    "qmltyperegistrar",
+    "linguist",
+    "lupdate",
+    "lrelease",
+    "lconvert",
+    "designer",
+    "assistant",
+    "qhelpgenerator",
+    "qcollectiongenerator",
+    "qtdiag",
+    "rcc",
+    "uic",
+    "shiboken6",
+    "balsam",
+    "balsamui",
+    "deployqt",
+    "androiddeployqt",
+    "include",
+    "typesystems",
+    "scripts",
+    "support",
+    "examples",
+    "glue",
+)
+
+# Plugin subdirectories under PySide6/Qt/plugins/ that go with the
+# disabled modules above.
+_QT_PLUGIN_DROP = (
+    "qmltooling",
+    "qml1tooling",
+    "scenegraph",
+    "multimedia",
+    "multimediabackends",
+    "mediaservice",
+    "playlistformats",
+    "audio",
+    "video",
+    "printsupport",
+    "sqldrivers",
+    "designer",
+    "webview",
+    "geometryloaders",
+    "renderers",
+    "renderplugins",
+    "sceneparsers",
+    "geoservices",
+    "position",
+    "sensors",
+    "sensorgestures",
+    "texttospeech",
+    "canbus",
+    "bearer",
+    "networkinformation",
+    "networkaccess",
+    "gamepads",
+    "egldeviceintegrations",
+    "qmldebugbackends",
+)
+
+
+def _delete(path, removed):
+    """Remove `path` (file or directory) and bookkeep bytes freed."""
+    try:
+        if path.is_dir() and not path.is_symlink():
+            size = sum(p.stat().st_size for p in path.rglob("*") if p.is_file())
+            shutil.rmtree(path)
+        else:
+            size = path.stat().st_size
+            path.unlink()
+        removed["count"] += 1
+        removed["bytes"] += size
+    except OSError as exc:
+        print(f"  warn: could not remove {path}: {exc}")
+
+
+def trim_pyside6(target_site_packages):
+    """Delete PySide6/Qt6 components the runtime app never imports.
+
+    The app uses only QtCore/QtGui/QtWidgets. Everything else
+    (WebEngine, QML, Multimedia, 3D, Charts, ...) is dead weight and
+    accounts for most of the AppImage size.
+    """
+    pyside = Path(target_site_packages) / "PySide6"
+    if not pyside.exists():
+        print("trim_pyside6: PySide6 not found, nothing to trim")
+        return
+
+    before = sum(p.stat().st_size for p in pyside.rglob("*") if p.is_file())
+    removed = {"count": 0, "bytes": 0}
+    print(f"trim_pyside6: starting; PySide6 currently {before / 1024 / 1024:.1f} MB")
+
+    # 1) Devtools and build-time directories at PySide6 top level.
+    for name in _PYSIDE6_TOP_LEVEL_DROP:
+        path = pyside / name
+        if path.exists():
+            _delete(path, removed)
+
+    # 2) Top-level binding files for unused modules:
+    #    Qt<Mod>.abi3.so, Qt<Mod>.pyi, Qt<Mod>.so, etc.
+    for child in list(pyside.iterdir()):
+        if not child.is_file():
+            continue
+        stem = child.name
+        for prefix in _PYSIDE6_MODULE_DENYLIST:
+            if stem.startswith(f"Qt{prefix}"):
+                _delete(child, removed)
+                break
+
+    # 3) Bulky Qt asset trees. We keep `lib/` (filtered below),
+    #    `plugins/` (filtered below), and `libexec/`.
+    qt = pyside / "Qt"
+    if qt.exists():
+        for asset in ("qml", "resources", "translations", "metatypes"):
+            path = qt / asset
+            if path.exists():
+                _delete(path, removed)
+
+        # 4) Qt 6 shared libs in Qt/lib for unused modules + FFmpeg.
+        lib_dir = qt / "lib"
+        if lib_dir.exists():
+            for so in list(lib_dir.iterdir()):
+                if not so.is_file() and not so.is_symlink():
+                    continue
+                name = so.name
+                if any(name.startswith(p) for p in _FFMPEG_LIB_PREFIXES):
+                    _delete(so, removed)
+                    continue
+                if not name.startswith("libQt6"):
+                    continue
+                # libQt6<Module>.so.6 / .so.6.x.y
+                tail = name[len("libQt6") :]
+                for prefix in _PYSIDE6_MODULE_DENYLIST:
+                    if tail.startswith(prefix):
+                        _delete(so, removed)
+                        break
+
+        # 5) Plugin subdirectories that go with the disabled modules.
+        plugins = qt / "plugins"
+        if plugins.exists():
+            for sub in _QT_PLUGIN_DROP:
+                path = plugins / sub
+                if path.exists():
+                    _delete(path, removed)
+
+    after = sum(p.stat().st_size for p in pyside.rglob("*") if p.is_file())
+    saved = before - after
+    print(
+        f"trim_pyside6: removed {removed['count']} entries, "
+        f"freed {saved / 1024 / 1024:.1f} MB; PySide6 now "
+        f"{after / 1024 / 1024:.1f} MB"
+    )
 
 
 def copy_system_libraries(appdir):


### PR DESCRIPTION
This pull request streamlines the AppImage build process by reducing unnecessary dependencies and significantly trimming unused PySide6/Qt6 components. The main focus is on minimizing the size of the final AppImage by removing unneeded modules, plugins, and system commands, as well as optimizing which Python packages are included.

**AppImage size reduction and dependency optimization:**

* Added a `trim_pyside6` function to aggressively remove unused PySide6/Qt6 modules, plugins, and development tools, keeping only the components required at runtime (QtCore, QtGui, QtWidgets). This is expected to save substantial disk space in the AppImage.
* Skipped copying install-time-only Python packages (`pip`, `setuptools`, `pkg_resources`, `_distutils_hack`) into the AppImage, as they are not needed at runtime, further reducing the image size.

**System command and dependency cleanup:**

* Removed the `convert` utility from the list of required and bundled system commands, as it is no longer needed for the application. [[1]](diffhunk://#diff-3e8b25c0da2ac1d0cb1f329c31846ef9e965642788287c23d2ea0f3de97cae64L84-R84) [[2]](diffhunk://#diff-3e8b25c0da2ac1d0cb1f329c31846ef9e965642788287c23d2ea0f3de97cae64L493-R698)